### PR TITLE
Issue #20 add @GSR command to rotate to a step position.

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -138,6 +138,7 @@ DW  | R       | ddddd     | :DWR#      | @DWR,300   | Write Dead-zone in steps [
 FR  | RS      | none      | :FRstring# | @FRR       | Reads the semantic version (SemVer) string of the firmware.
 GA  | R       | ddd       | :GAR#      | @GAR,180   | Goto Azimuth (param: integer degrees)
 GH  | R       | none      | :GHR#      | @GHR       | Rotates clockwise until the home sensor is detected and synchronizes the azimuth to the home position.
+GS  | R       | ddddd     | :GSR#      | @GSR,1000  | Goto whole step position (0 <=param <= @RRR)
 HR  | R       | none      | :HRRddddd# | @HRR       | Home position Read (steps clockwise from true north)
 HW  | R       | ddddd     | :HWR#      | @HWR,1000  | Home position Write (seps clockwise from true north)
 PR  | RS      | none      | :PRt-dddd# | @PRR       | Position Read - get current step position in whole steps (signed integer)

--- a/TA.NexDome.Rotator/CommandProcessor.h
+++ b/TA.NexDome.Rotator/CommandProcessor.h
@@ -39,6 +39,8 @@ private:
 	Response HandleAW(Command& command) const; // AW - Acceleration ramp time write
 	Response HandleFR(Command& command) const; // Firmware version read
 	Response HandleGA(Command& command) const; // GA - GoTo Azimuth (in degrees).
+	void rotateToMicrostepPosition(int32_t target) const;
+	Response HandleGS(Command& command) const; // GS - GoTo Step Position
 	Response HandleGH(Command& command) const; // Go to home sensor
 	Response HandleHR(Command& command) const; // Read Home position (steps clockwise from true north)
 	Response HandleHW(Command& command) const; // Write home position (steps clockwise from true north)


### PR DESCRIPTION

[TA.NexDome.Rotator-3.2.0-issue-20.16.zip](https://github.com/nexdome/Firmware/files/3908458/TA.NexDome.Rotator-3.2.0-issue-20.16.zip)

Experimental feature to add high precision positioning to the rotator.

Adds a new firmware command `@GSR` "Goto step-position". Allows the rotator to be positioned with a resolution of 1 whole step. There are 55,080 whole steps per revolution, so this gives a theoretical positioning resolution of 360/55080 = 0.00654 degrees.