### PR TITLE
Release 3.2.0

### DIFF
--- a/Deploy-Firmware.ps1
+++ b/Deploy-Firmware.ps1
@@ -26,10 +26,8 @@ else {
     Remove-Item "$DeployDirectory\ReadMe.pdf" -ErrorAction Ignore
 }
 
-Copy-Item ".\TA.NexDome.Rotator\Release\TA.NexDome.Rotator.hex" -Destination "$DeployDirectory\" -Force
-Copy-Item ".\TA.NexDome.Shutter\Release\TA.NexDome.Shutter.hex" -Destination "$DeployDirectory\" -Force
-Copy-Item ".\XBeeFactoryReset\Release\XBeeFactoryReset.hex" -Destination "$DeployDirectory\" -Force
-Copy-Item ".\ReadMe.pdf" -Destination "$DeployDirectory\" -Force
+Copy-Item ".\TA.NexDome.Rotator\Release\TA.NexDome.Rotator.hex" -Destination "$DeployDirectory\Rotator-$semver.hex" -Force
+Copy-Item ".\TA.NexDome.Shutter\Release\TA.NexDome.Shutter.hex" -Destination "$DeployDirectory\Shutter-$semver.hex" -Force
 
 Write-Host "Deploy complete. Now build the ASCOM driver solution."
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -138,6 +138,7 @@ DW  | R       | ddddd     | :DWR#      | @DWR,300   | Write Dead-zone in steps [
 FR  | RS      | none      | :FRstring# | @FRR       | Reads the semantic version (SemVer) string of the firmware.
 GA  | R       | ddd       | :GAR#      | @GAR,180   | Goto Azimuth (param: integer degrees)
 GH  | R       | none      | :GHR#      | @GHR       | Rotates clockwise until the home sensor is detected and synchronizes the azimuth to the home position.
+GS  | R       | ddddd     | :GSR#      | @GSR,1000  | Goto whole step position (0 <=param <= @RRR)
 HR  | R       | none      | :HRRddddd# | @HRR       | Home position Read (steps clockwise from true north)
 HW  | R       | ddddd     | :HWR#      | @HWR,1000  | Home position Write (seps clockwise from true north)
 PR  | RS      | none      | :PRt-dddd# | @PRR       | Position Read - get current step position in whole steps (signed integer)

--- a/TA.NexDome.Rotator/CommandProcessor.h
+++ b/TA.NexDome.Rotator/CommandProcessor.h
@@ -39,6 +39,8 @@ private:
 	Response HandleAW(Command& command) const; // AW - Acceleration ramp time write
 	Response HandleFR(Command& command) const; // Firmware version read
 	Response HandleGA(Command& command) const; // GA - GoTo Azimuth (in degrees).
+	void rotateToMicrostepPosition(int32_t target) const;
+	Response HandleGS(Command& command) const; // GS - GoTo Step Position
 	Response HandleGH(Command& command) const; // Go to home sensor
 	Response HandleHR(Command& command) const; // Read Home position (steps clockwise from true north)
 	Response HandleHW(Command& command) const; // Write home position (steps clockwise from true north)

--- a/TA.NexDome.Shutter/LimitSwitch.h
+++ b/TA.NexDome.Shutter/LimitSwitch.h
@@ -12,19 +12,22 @@
 #include <AdvancedStepper.h>
 
 class LimitSwitch
-{
-public:
-	LimitSwitch(MicrosteppingMotor* stepper, uint8_t openLimit, uint8_t closeLimit);
-	bool isOpen() const;
-	bool isClosed() const;
-	void init();
-private:
-	uint8_t openLimitPin;
-	uint8_t closedLimitPin;
-	static MicrosteppingMotor * motor;
-	static void onOpenLimitReached();
-	static void onCloseLimitReached();
-};
+	{
+	public:
+		LimitSwitch(MicrosteppingMotor* stepper, uint8_t openLimit, uint8_t closeLimit);
+		bool isOpen() const;
+		bool isClosed() const;
+		void init() const;
+		void onMotorStopped();
+
+	private:
+		uint8_t openLimitPin;
+		uint8_t closedLimitPin;
+		static volatile bool closeTriggered;
+		static MicrosteppingMotor* motor;
+		static void onOpenLimitReached();
+		static void onCloseLimitReached();
+	};
 
 #endif
 

--- a/TA.NexDome.Shutter/TA.NexDome.Shutter.ino
+++ b/TA.NexDome.Shutter/TA.NexDome.Shutter.ino
@@ -182,5 +182,6 @@ void loop()
 // Handle the motor stop event from the stepper driver.
 void onMotorStopped()
 	{
+	limitSwitches.onMotorStopped();
 	commandProcessor.sendStatus();
 	}


### PR DESCRIPTION
This firmware release adds a new _High Precision Slewing_ feature and improves the operation of the shutter close limit sensor under adverse conditions.

# High Precision Slewing #20
- adds a new command `@GSR,nnnnn` "Goto step-position" that allows positioning of the rotator with a resolution of a single motor step, or about 0.006 degrees.
- Note that this level of precision is far higher than can actually be achieved in practice because of backlash and other mechanical considerations.
- Drivers and applications can use this new command to implement more accurate positioning, which is especially useful for users with large telescopes (C14) that need extremely accurate scope/dome synchronization.
- The _Dead Zone_ is still in effect for high precision slewing. The default value for dead-zone has been reduced from 300 steps to 100 steps (about 1/6th degree). To get the new dead-zone value you will either have to reset to factory defaults, or manually reduce the dead zone to a smaller value using the `@DWR` command. Be conservative when reducing the dead-zone and only reduce it as much as absolutely necessary. Setting the dead-zone too low may result in "hunting" or other adverse effects.
- Drivers and application plugins must compute the target step position using the formula: `position` = `circumference` / 360.0 * `azimuth`
- The value for `circumference` is obtained using the `@RRR` command and it is suggested that this be done once at the start of a session immediately after connecting.
- Pull request #21 closes #20 

# Shutter Close Limit Idempotency #22

Per issue #22 it was found that under some (not very well understood) circumstances the close limit sensor can be re-triggered multiple times as the shutter approaches the magnet. Most installations don't exhibit this problem and the root cause, probably mechanical, could not be fully determined. However the firmware reacted badly to this situation and clearly needed to be improved.

The close limit sensor should be _idempotent_, that is, triggering it multiple times should produce the same result as triggering it once. The firmware has been updated to ensure that the close limit sensor is idempotent. The `onMotorStopped()` event re-arms the close limit sensor and allows it to be triggered again. The effect is that the close limit sensor can now only be triggered once while the motor is running, which gives the desired result. Closes #22 